### PR TITLE
don't enable whitespace changes by default

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -2,10 +2,10 @@ Whitespace = require './whitespace'
 
 module.exports =
   configDefaults:
-    removeTrailingWhitespace: true
+    removeTrailingWhitespace: false
     ignoreWhitespaceOnCurrentLine: true
     ignoreWhitespaceOnlyLines: false
-    ensureSingleTrailingNewline: true
+    ensureSingleTrailingNewline: false
 
   activate: ->
     @whitespace = new Whitespace()


### PR DESCRIPTION
This package is installed and enabled by default, so its default behavior should probably not be so opinionated.

I think it is less annoying to seek out and enable whitespace changes if desired than it is to discover undesired changes, undo them, and seek out and disable the behavior.
