### PR TITLE
Add command to remove trailing whitespace

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -9,6 +9,11 @@ module.exports =
 
   activate: ->
     @whitespace = new Whitespace()
+    atom.workspaceView.command 'whitespace:remove-trailing-whitespace', =>
+      if @whitespace? and editor = atom.workspace.getActiveEditor()
+        @whitespace.removeTrailingWhitespace editor, editor.getGrammar().scopeName
+
 
   deactivate: ->
-    @whitespace.destroy()
+    @whitespace?.destroy()
+    @whitespace = null

--- a/spec/whitespace-spec.coffee
+++ b/spec/whitespace-spec.coffee
@@ -235,3 +235,24 @@ describe "Whitespace", ->
         editor.setText("foo \n")
         editor.save()
         expect(editor.getText()).toBe "foo \n"
+
+  describe "when the 'whitespace:remove-trailing-whitespace' command is run", ->
+    whitespace = null
+
+    beforeEach ->
+      whitespace = atom.packages.getActivePackage('whitespace').mainModule.whitespace
+      spyOn whitespace, 'removeTrailingWhitespace'
+
+    it "runs 'whitespace.removeTrailingWhitespace'", ->
+      atom.workspaceView.trigger 'whitespace:remove-trailing-whitespace'
+      expect(whitespace.removeTrailingWhitespace).toHaveBeenCalled()
+
+    it "does not attempt to remove whitespace when there is no buffer", ->
+      editor.destroy()
+      atom.workspaceView.trigger 'whitespace:remove-trailing-whitespace'
+      expect(whitespace.removeTrailingWhitespace).not.toHaveBeenCalled()
+
+    it "does not attempt to remove whitespace when the plugin is disabled", ->
+      atom.packages.deactivatePackage 'whitespace'
+      atom.workspaceView.trigger 'whitespace:remove-trailing-whitespace'
+      expect(whitespace.removeTrailingWhitespace).not.toHaveBeenCalled()


### PR DESCRIPTION
Simply adds a command to remove trailing whitespace.

![image](https://f.cloud.github.com/assets/210630/2362050/5359d8ec-a639-11e3-8c76-21c32c3a5520.png)
