### PR TITLE
:bug::shoe: prevents orphaned editor in buffer destroy listener

### DIFF
--- a/lib/whitespace.coffee
+++ b/lib/whitespace.coffee
@@ -21,6 +21,9 @@ class Whitespace
         if atom.config.get('whitespace.ensureSingleTrailingNewline')
           @ensureSingleTrailingNewline(editor)
 
+    @subscribe editor, 'destroyed', =>
+      @unsubscribe(buffer)
+
     @subscribe buffer, 'destroyed', =>
       @unsubscribe(buffer)
 

--- a/spec/whitespace-spec.coffee
+++ b/spec/whitespace-spec.coffee
@@ -20,6 +20,19 @@ describe "Whitespace", ->
     waitsForPromise ->
       atom.packages.activatePackage('whitespace')
 
+  describe "when we destroy an editor with the same buffer", ->
+    beforeEach ->
+      atom.config.set("whitespace.ensureSingleTrailingNewline", true)
+
+    it "should unsubscribe from the buffer", ->
+      pane = atom.workspace.getActivePane()
+      newEditor = editor.copy()
+      newBuffer = newEditor.getBuffer()
+      pane.splitRight({items: [newEditor]})
+      editor.destroy()
+      newBuffer.setText("not empty")
+      expect(-> newBuffer.save()).not.toThrow()
+
   describe "when the editor is destroyed", ->
     beforeEach ->
       editor.destroy()


### PR DESCRIPTION
Previously, the whitespace package would bind listeners on `buffer` events per `editor`, and unbind when the `buffer` was `destroyed`.

The problem is apparent when you use split a `pane` because, currently, the new copied `editor` is assigned the same `buffer`. As a result, if you close one of the `editor`s, the listener is still bound with a reference to an editor that is no longer in your active `workspace` (because the `buffer` hasn't been destroyed yet).

This ultimately throws when you call `getSelectedBufferRanges` on the orphaned `editor` in `ensureSingleTrailingNewline` (introduced in dbb992ba723a25a953c63b55d5edf669ebf637ea).

My test is probably pretty bad (`getActivePane`? :rage4:) but I bounced around dev tools until I learned _just_ enough API to write it so no hard feelings if you :trashcan: it.

Also, make :trashcan: a thing pretty please.

Here's a gif demonstrating the issue:
![buffer](https://f.cloud.github.com/assets/62923/2392545/864335b6-a97a-11e3-8906-807f05933cbf.gif)

Steps to reproduce:
1. Enable `ensureSingleTrailingNewline`
1. Save a file with a trailing new line
2. Split that file
3. Close the original editor
4. Remove trailing newline from the other editor
5. Attempt to save
