### PR TITLE
Key bindings support

### DIFF
--- a/keymaps/whitespace.cson
+++ b/keymaps/whitespace.cson
@@ -1,0 +1,5 @@
+# For more detailed documentation see
+# https://atom.io/docs/latest/advanced/keymaps
+'.editor':
+  'ctrl-shift-[': 'whitespace:convert-spaces-to-tabs'
+  'ctrl-shift-]': 'whitespace:convert-tabs-to-spaces'


### PR DESCRIPTION
Default keys are set to following: (don't seem to conflict with anything)
- `ctrl-shift-[`: Convert Spaces To Tabs
- `ctrl-shift-]`: Convert Tabs To Spaces

![screenshot from 2014-07-15 21 23 02](https://cloud.githubusercontent.com/assets/7157049/3590880/d9d654ec-0c5d-11e4-9ec8-e301e08e6850.png)
