### PR TITLE
Remove Destructive Defaults

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -2,7 +2,7 @@ Whitespace = require './whitespace'
 
 module.exports =
   configDefaults:
-    removeTrailingWhitespace: true
+    removeTrailingWhitespace: false
     ignoreWhitespaceOnCurrentLine: true
     ignoreWhitespaceOnlyLines: false
     ensureSingleTrailingNewline: true


### PR DESCRIPTION
Having a configuration that is destructive by default is extremely dangerous, and results in a poor first-time user experience.  This problem often will not manifest itself until the most inopportune of times, leaping upon the unsuspecting user who many not be aware of this plugin or its configuration options.

This is of particular concern to users of NodeJS, Jade, and subscribers to issue #10.
