### PR TITLE
Add scoped defaults for Markdown

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -8,6 +8,8 @@ module.exports =
       scopes:
         '.source.jade':
           default: false
+        '.source.gfm':
+          default: false
     ignoreWhitespaceOnCurrentLine:
       type: 'boolean'
       default: true


### PR DESCRIPTION
Disable trailing whitespace removal by default for Markdown files (GFM).
Two trailing spaces in GFM are used to insert a line break.
