### PR TITLE
add option to only trim whitespace on modified lines if project is a Git-repo

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -14,6 +14,9 @@ module.exports =
     ignoreWhitespaceOnlyLines:
       type: 'boolean'
       default: false
+    onlyModifiedLines:
+      type: 'boolean'
+      default: true
     ensureSingleTrailingNewline:
       type: 'boolean'
       default: true

--- a/lib/whitespace.coffee
+++ b/lib/whitespace.coffee
@@ -1,5 +1,5 @@
 {CompositeDisposable} = require 'atom'
-_ = require 'underscore'
+_ = require 'underscore-plus'
 
 module.exports =
 class Whitespace

--- a/lib/whitespace.coffee
+++ b/lib/whitespace.coffee
@@ -46,10 +46,10 @@ class Whitespace
   removeTrailingWhitespace: (editor, grammarScopeName) ->
     buffer = editor.getBuffer()
     scopeDescriptor = editor.getRootScopeDescriptor()
-    modifiedRows = @getModifiedRows(editor)
     ignoreCurrentLine = atom.config.get('whitespace.ignoreWhitespaceOnCurrentLine', scope: scopeDescriptor)
     ignoreWhitespaceOnlyLines = atom.config.get('whitespace.ignoreWhitespaceOnlyLines', scope: scopeDescriptor)
     onlyModifiedLines = atom.config.get('whitespace.onlyModifiedLines', scope: scopeDescriptor)
+    modifiedRows = @getModifiedRows(editor) if onlyModifiedLines
 
     buffer.backwardsScan /[ \t]+$/g, ({lineText, match, replace}) ->
       whitespaceRow = buffer.positionForCharacterIndex(match.index).row
@@ -103,7 +103,7 @@ class Whitespace
   getModifiedRows: (editor) ->
     if path = editor?.getPath()
       if diffs = atom.project.getRepositories()[0]?.getLineDiffs(path, editor.getText())
-        modifiedRows = diffs.map ({oldStart, newStart, oldLines, newLines}) ->
+        modifiedRows = diffs.map ({newStart, oldLines, newLines}) ->
           startRow = newStart - 1
           endRow = newStart + newLines - 2
           # removed section

--- a/lib/whitespace.coffee
+++ b/lib/whitespace.coffee
@@ -46,7 +46,7 @@ class Whitespace
   removeTrailingWhitespace: (editor, grammarScopeName) ->
     buffer = editor.getBuffer()
     scopeDescriptor = editor.getRootScopeDescriptor()
-    modifiedRows = @_getModifiedRows(editor)
+    modifiedRows = @getModifiedRows(editor)
     ignoreCurrentLine = atom.config.get('whitespace.ignoreWhitespaceOnCurrentLine', scope: scopeDescriptor)
     ignoreWhitespaceOnlyLines = atom.config.get('whitespace.ignoreWhitespaceOnlyLines', scope: scopeDescriptor)
     onlyModifiedLines = atom.config.get('whitespace.onlyModifiedLines', scope: scopeDescriptor)
@@ -94,9 +94,13 @@ class Whitespace
     buffer.transact ->
       buffer.scan new RegExp(spacesText, 'g'), ({replace}) -> replace('\t')
 
-  # returns null if no current Git-repo or file is new and unsaved
-  # returns Array[Number] where each index is a modified row
-  _getModifiedRows: (editor) ->
+  # Private: Gets the list of modified rows.
+  #
+  # * `editor` {TextEditor} to retrieve the modified rows from.
+  #
+  # Returns null if there is no repository or file is new and unsaved.
+  # Returns {Array} of modified row {Number}.
+  getModifiedRows: (editor) ->
     if path = editor?.getPath()
       if diffs = atom.project.getRepositories()[0]?.getLineDiffs(path, editor.getText())
         modifiedRows = diffs.map ({oldStart, newStart, oldLines, newLines}) ->

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "fs-plus": "2.x",
-    "temp": "~0.8.1"
+    "temp": "~0.8.1",
+    "underscore": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
   "dependencies": {
     "fs-plus": "2.x",
     "temp": "~0.8.1",
-    "underscore": "*"
+    "underscore-plus": "^1.6.6"
   }
 }


### PR DESCRIPTION
Implements issue #8

* option defaults to true.
* quick implementation. there might be bugs, but it seems to work very well.
* no tests yet.

This is my first time hacking on Atom-packages. I'd like some feedback and review. What's missing? What needs adjustments? I will try adding some tests later hopefully.