### PR TITLE
add whitespace:save-without-modifying command

### DIFF
--- a/lib/whitespace.coffee
+++ b/lib/whitespace.coffee
@@ -48,8 +48,8 @@ class Whitespace
     @editorSubscriptions.add(bufferDestroyedSubscription)
 
   saveWithoutModifying: (editor) ->
+    @editorSubscriptions.dispose()
     try
-      @editorSubscriptions.dispose()
       editor.save()
     finally
       @editorSubscriptions = new CompositeDisposable

--- a/menus/whitespace.cson
+++ b/menus/whitespace.cson
@@ -7,6 +7,7 @@
         { 'label': 'Remove Trailing Whitespace', 'command': 'whitespace:remove-trailing-whitespace' }
         { 'label': 'Convert Tabs To Spaces', 'command': 'whitespace:convert-tabs-to-spaces' }
         { 'label': 'Convert Spaces To Tabs', 'command': 'whitespace:convert-spaces-to-tabs' }
+        { 'label': 'Save Without Modifying Whitespace', 'command': 'whitespace:save-without-modifying' }
       ]
     ]
   }

--- a/spec/whitespace-spec.coffee
+++ b/spec/whitespace-spec.coffee
@@ -286,3 +286,25 @@ describe "Whitespace", ->
       buffer.setText("   a\n   \nb   \nc      d"
       atom.commands.dispatch(workspaceElement, 'whitespace:convert-spaces-to-tabs')
       expect(buffer.getText()).toBe '\ta\n\t\nb\t\nc\t\td')
+
+  describe "when the 'whitespace:save-without-modifying' command is run", ->
+    beforeEach ->
+      atom.config.set("whitespace.removeTrailingWhitespace", true)
+      atom.config.set("whitespace.ensureSingleTrailingNewline", true)
+
+    it "saves the buffer without modifying whitespace", ->
+      editor.insertText("foo   \nbar\t   \n\nbaz\n\n")
+      atom.commands.dispatch(workspaceElement, 'whitespace:save-without-modifying')
+      expect(editor.getText()).toBe "foo   \nbar\t   \n\nbaz\n\n"
+      expect(editor.isModified()).toBe false
+
+  describe "when the editor is saved normally after 'whitespace:save-without-modifying' was run", ->
+    beforeEach ->
+      atom.config.set("whitespace.removeTrailingWhitespace", true)
+      atom.config.set("whitespace.ensureSingleTrailingNewline", true)
+      editor.insertText("foo   \nbar\t   \n\nbaz\n\n")
+      atom.commands.dispatch(workspaceElement, 'whitespace:save-without-modifying')
+
+    it "modifies whitespace before the editor saves a buffer", ->
+      editor.save()
+      expect(editor.getText()).toBe "foo\nbar\n\nbaz\n"


### PR DESCRIPTION
Adds a `whitespace:save-without-modifying` command to the `whitespace` package, which saves the current editor's buffer without applying any changes from the `whitespace` package (enhancement request #11).

This works by unregistering editor events, saving the current editor, and reregistering them after the save. This feels a bit more like a sledgehammer than a scalpel, but is it much simpler than tracking state so that we can _only_ unregister events for the target editor, or trying to inject some context that `removeTrailingWhitespace` and friends will check before editing.

The `CompositeDisposable` containing the events is split into two parts, so that we don't unregister and deregister the commands as well.