### PR TITLE
Move special Markdown line break whitespace handling to configuration

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -12,7 +12,7 @@ module.exports =
       type: 'boolean'
       default: true
       description: '''
-      Markdown uses two ore more spaces at the end of a line to signify a line break. Enable this
+      Markdown uses two or more spaces at the end of a line to signify a line break. Enable this
       option to keep this whitespace, even if other settings would remove it.
       '''
     ignoreWhitespaceOnCurrentLine:

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -8,6 +8,9 @@ module.exports =
       scopes:
         '.source.jade':
           default: false
+    ignoreMarkdownLineBreak:
+      type: 'boolean'
+      default: true
     ignoreWhitespaceOnCurrentLine:
       type: 'boolean'
       default: true

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -8,9 +8,13 @@ module.exports =
       scopes:
         '.source.jade':
           default: false
-    ignoreMarkdownLineBreak:
+    keepMarkdownLineBreakWhitespace:
       type: 'boolean'
       default: true
+      description: '''
+      Markdown uses two ore more spaces at the end of a line to signify a line break. Enable this
+      option to keep this whitespace, even if other settings would remove it.
+      '''
     ignoreWhitespaceOnCurrentLine:
       type: 'boolean'
       default: true

--- a/lib/whitespace.coffee
+++ b/lib/whitespace.coffee
@@ -56,7 +56,7 @@ class Whitespace
       [whitespace] = match
       return if ignoreWhitespaceOnlyLines and whitespace is lineText
 
-      if grammarScopeName is 'source.gfm' and atom.config.get('whitespace.ignoreMarkdownLineBreak')
+      if grammarScopeName is 'source.gfm' and atom.config.get('whitespace.keepMarkdownLineBreakWhitespace')
         # GitHub Flavored Markdown permits two or more spaces at the end of a line
         replace('') unless whitespace.length >= 2 and whitespace isnt lineText
       else

--- a/lib/whitespace.coffee
+++ b/lib/whitespace.coffee
@@ -56,9 +56,9 @@ class Whitespace
       [whitespace] = match
       return if ignoreWhitespaceOnlyLines and whitespace is lineText
 
-      if grammarScopeName is 'source.gfm'
-        # GitHub Flavored Markdown permits two spaces at the end of a line
-        replace('') unless whitespace is '  ' and whitespace isnt lineText
+      if grammarScopeName is 'source.gfm' and atom.config.get('whitespace.ignoreMarkdownLineBreak')
+        # GitHub Flavored Markdown permits two or more spaces at the end of a line
+        replace('') unless whitespace.length >= 2 and whitespace isnt lineText
       else
         replace('')
 

--- a/spec/whitespace-spec.coffee
+++ b/spec/whitespace-spec.coffee
@@ -182,10 +182,10 @@ describe "Whitespace", ->
       expect(editor.getText()).toBe "no trailing newline"
 
   describe "GFM whitespace trimming", ->
-    describe 'when ignoreMarkdownLineBreak is true', ->
+    describe 'when keepMarkdownLineBreakWhitespace is true', ->
       beforeEach ->
         atom.config.set("whitespace.ignoreWhitespaceOnCurrentLine", false)
-        atom.config.set("whitespace.ignoreMarkdownLineBreak", true)
+        atom.config.set("whitespace.keepMarkdownLineBreakWhitespace", true)
 
         waitsForPromise ->
           atom.packages.activatePackage("language-gfm")
@@ -232,10 +232,10 @@ describe "Whitespace", ->
         editor.save()
         expect(editor.getText()).toBe "\t \nline break!\n"
 
-    describe 'when ignoreMarkdownLineBreak is false', ->
+    describe 'when keepMarkdownLineBreakWhitespace is false', ->
       beforeEach ->
         atom.config.set("whitespace.ignoreWhitespaceOnCurrentLine", false)
-        atom.config.set("whitespace.ignoreMarkdownLineBreak", false)
+        atom.config.set("whitespace.keepMarkdownLineBreakWhitespace", false)
 
         waitsForPromise ->
           atom.packages.activatePackage("language-gfm")

--- a/spec/whitespace-spec.coffee
+++ b/spec/whitespace-spec.coffee
@@ -182,53 +182,105 @@ describe "Whitespace", ->
       expect(editor.getText()).toBe "no trailing newline"
 
   describe "GFM whitespace trimming", ->
-    beforeEach ->
-      atom.config.set("whitespace.ignoreWhitespaceOnCurrentLine", false)
+    describe 'when ignoreMarkdownLineBreak is true', ->
+      beforeEach ->
+        atom.config.set("whitespace.ignoreWhitespaceOnCurrentLine", false)
+        atom.config.set("whitespace.ignoreMarkdownLineBreak", true)
 
-      waitsForPromise ->
-        atom.packages.activatePackage("language-gfm")
+        waitsForPromise ->
+          atom.packages.activatePackage("language-gfm")
 
-      runs ->
-        editor.setGrammar(atom.grammars.grammarForScopeName("source.gfm"))
+        runs ->
+          editor.setGrammar(atom.grammars.grammarForScopeName("source.gfm"))
 
-    it "trims GFM text with a single space", ->
-      editor.insertText "foo \nline break!"
-      editor.save()
-      expect(editor.getText()).toBe "foo\nline break!\n"
+      it "trims GFM text with a single space", ->
+        editor.insertText "foo \nline break!"
+        editor.save()
+        expect(editor.getText()).toBe "foo\nline break!\n"
 
-    it "leaves GFM text with double spaces alone", ->
-      editor.insertText "foo  \nline break!"
-      editor.save()
-      expect(editor.getText()).toBe "foo  \nline break!\n"
+      it "leaves GFM text with double spaces alone", ->
+        editor.insertText "foo  \nline break!"
+        editor.save()
+        expect(editor.getText()).toBe "foo  \nline break!\n"
 
-    it "trims GFM text with a more than two spaces", ->
-      editor.insertText "foo   \nline break!"
-      editor.save()
-      expect(editor.getText()).toBe "foo\nline break!\n"
+      it "leaves GFM text with a more than two spaces", ->
+        editor.insertText "foo   \nline break!"
+        editor.save()
+        expect(editor.getText()).toBe "foo   \nline break!\n"
 
-    it "trims empty lines", ->
-      editor.insertText "foo\n  "
-      editor.save()
-      expect(editor.getText()).toBe "foo\n"
+      it "trims empty lines", ->
+        editor.insertText "foo\n  "
+        editor.save()
+        expect(editor.getText()).toBe "foo\n"
 
-      editor.setText "foo\n "
-      editor.save()
-      expect(editor.getText()).toBe "foo\n"
+        editor.setText "foo\n "
+        editor.save()
+        expect(editor.getText()).toBe "foo\n"
 
-    it "respects 'whitespace.ignoreWhitespaceOnCurrentLine' setting", ->
-      atom.config.set("whitespace.ignoreWhitespaceOnCurrentLine", true)
+      it "respects 'whitespace.ignoreWhitespaceOnCurrentLine' setting", ->
+        atom.config.set("whitespace.ignoreWhitespaceOnCurrentLine", true)
 
-      editor.insertText "foo \nline break!"
-      editor.setCursorBufferPosition([0, 4])
-      editor.save()
-      expect(editor.getText()).toBe "foo \nline break!\n"
+        editor.insertText "foo \nline break!"
+        editor.setCursorBufferPosition([0, 4])
+        editor.save()
+        expect(editor.getText()).toBe "foo \nline break!\n"
 
-    it "respects 'whitespace.ignoreWhitespaceOnlyLines' setting", ->
-      atom.config.set("whitespace.ignoreWhitespaceOnlyLines", true)
+      it "respects 'whitespace.ignoreWhitespaceOnlyLines' setting", ->
+        atom.config.set("whitespace.ignoreWhitespaceOnlyLines", true)
 
-      editor.insertText "\t \nline break!"
-      editor.save()
-      expect(editor.getText()).toBe "\t \nline break!\n"
+        editor.insertText "\t \nline break!"
+        editor.save()
+        expect(editor.getText()).toBe "\t \nline break!\n"
+
+    describe 'when ignoreMarkdownLineBreak is false', ->
+      beforeEach ->
+        atom.config.set("whitespace.ignoreWhitespaceOnCurrentLine", false)
+        atom.config.set("whitespace.ignoreMarkdownLineBreak", false)
+
+        waitsForPromise ->
+          atom.packages.activatePackage("language-gfm")
+
+        runs ->
+          editor.setGrammar(atom.grammars.grammarForScopeName("source.gfm"))
+
+      it "trims GFM text with a single space", ->
+        editor.insertText "foo \nline break!"
+        editor.save()
+        expect(editor.getText()).toBe "foo\nline break!\n"
+
+      it "trims GFM text with two spaces", ->
+        editor.insertText "foo  \nline break!"
+        editor.save()
+        expect(editor.getText()).toBe "foo\nline break!\n"
+
+      it "trims GFM text with a more than two spaces", ->
+        editor.insertText "foo   \nline break!"
+        editor.save()
+        expect(editor.getText()).toBe "foo\nline break!\n"
+
+      it "trims empty lines", ->
+        editor.insertText "foo\n  "
+        editor.save()
+        expect(editor.getText()).toBe "foo\n"
+
+        editor.setText "foo\n "
+        editor.save()
+        expect(editor.getText()).toBe "foo\n"
+
+      it "respects 'whitespace.ignoreWhitespaceOnCurrentLine' setting", ->
+        atom.config.set("whitespace.ignoreWhitespaceOnCurrentLine", true)
+
+        editor.insertText "foo \nline break!"
+        editor.setCursorBufferPosition([0, 4])
+        editor.save()
+        expect(editor.getText()).toBe "foo \nline break!\n"
+
+      it "respects 'whitespace.ignoreWhitespaceOnlyLines' setting", ->
+        atom.config.set("whitespace.ignoreWhitespaceOnlyLines", true)
+
+        editor.insertText "\t \nline break!"
+        editor.save()
+        expect(editor.getText()).toBe "\t \nline break!\n"
 
   describe "when the editor is split", ->
     it "does not throw exceptions when the editor is saved after the split is closed (regression)", ->


### PR DESCRIPTION
Fixes #68, #80 

Moving it to a configuration setting allows it to be turned off.