### PR TITLE
Clear blank line on new line

### DIFF
--- a/lib/whitespace.coffee
+++ b/lib/whitespace.coffee
@@ -31,14 +31,14 @@ class Whitespace
         if atom.config.get('whitespace.ensureSingleTrailingNewline', scope: scopeDescriptor)
           @ensureSingleTrailingNewline(editor)
 
-    editorTextInsertedSubscription = editor.onDidInsertText (event) =>
+    editorTextInsertedSubscription = editor.onDidInsertText (event) ->
       return unless event.text is '\n'
-      scopeDescriptor = editor.getRootScopeDescriptor()
+      return unless buffer.isRowBlank(event.range.start.row)
 
+      scopeDescriptor = editor.getRootScopeDescriptor()
       if atom.config.get('whitespace.removeTrailingWhitespace', scope: scopeDescriptor)
         unless atom.config.get('whitespace.ignoreWhitespaceOnlyLines', scope: scopeDescriptor)
-          editor.transact =>
-            @clearBlankLineOnNewline(editor, event)
+          editor.setIndentationForBufferRow(event.range.start.row, 0)
 
     editorDestroyedSubscription = editor.onDidDestroy =>
       bufferSavedSubscription.dispose()
@@ -99,10 +99,3 @@ class Whitespace
 
     buffer.transact ->
       buffer.scan new RegExp(spacesText, 'g'), ({replace}) -> replace('\t')
-
-  clearBlankLineOnNewline: (editor, event) ->
-    buffer = editor.getBuffer()
-    previousRow = event.range.start.row
-
-    if buffer.isRowBlank(previousRow)
-      editor.setIndentationForBufferRow(previousRow, 0)

--- a/lib/whitespace.coffee
+++ b/lib/whitespace.coffee
@@ -32,10 +32,12 @@ class Whitespace
           @ensureSingleTrailingNewline(editor)
 
     editorTextInsertedSubscription = editor.onDidInsertText (event) =>
-      editor.transact =>
-        scopeDescriptor = editor.getRootScopeDescriptor()
-        if atom.config.get('whitespace.removeTrailingWhitespace', scope: scopeDescriptor)
-          unless atom.config.get('whitespace.ignoreWhitespaceOnlyLines', scope: scopeDescriptor)
+      return unless event.text is '\n'
+      scopeDescriptor = editor.getRootScopeDescriptor()
+
+      if atom.config.get('whitespace.removeTrailingWhitespace', scope: scopeDescriptor)
+        unless atom.config.get('whitespace.ignoreWhitespaceOnlyLines', scope: scopeDescriptor)
+          editor.transact =>
             @clearBlankLineOnNewline(editor, event)
 
     editorDestroyedSubscription = editor.onDidDestroy =>
@@ -99,9 +101,8 @@ class Whitespace
       buffer.scan new RegExp(spacesText, 'g'), ({replace}) -> replace('\t')
 
   clearBlankLineOnNewline: (editor, event) ->
-    return unless event.text is "\n"
     buffer = editor.getBuffer()
-    previousRow = editor.getCursorBufferPosition().row - 1
+    previousRow = event.range.start.row
 
     if buffer.isRowBlank(previousRow)
       editor.setIndentationForBufferRow(previousRow, 0)

--- a/spec/whitespace-spec.coffee
+++ b/spec/whitespace-spec.coffee
@@ -62,6 +62,28 @@ describe "Whitespace", ->
         editor.save()
         expect(editor.getText()).toBe 'Some text.\n'
 
+    it "clears blank lines when the editor inserts a newline", ->
+      # Need autoIndent to be true
+      atom.config.set 'editor.autoIndent', true
+      # Create an indent level and insert a newline
+      editor.setIndentationForBufferRow 0, 1
+      editor.insertText '\n'
+      expect(editor.getText()).toBe '\n  '
+
+      # Undo the newline insert and redo it
+      editor.undo()
+      expect(editor.getText()).toBe '  '
+      editor.redo()
+      expect(editor.getText()).toBe '\n  '
+
+      # Test for multiple cursors, possibly without blank lines
+      editor.insertText 'foo'
+      editor.insertText '\n'
+      editor.setCursorBufferPosition [1, 5]    # Cursor after 'foo'
+      editor.addCursorAtBufferPosition [2, 2]  # Cursor on the next line (blank)
+      editor.insertText '\n'
+      expect(editor.getText()).toBe '\n  foo\n  \n\n  '
+
   describe "when 'whitespace.removeTrailingWhitespace' is false", ->
     beforeEach ->
       atom.config.set("whitespace.removeTrailingWhitespace", false)


### PR DESCRIPTION
When a newline is inserted, check to see if the previous line is blank (only whitespace). If so, decrease the indent of that line to zero. For this to work, `whitespace.removeTrailingWhitespace` must be true and `whitespace.ignoreWhitespaceOnlyLines` must be false as per [atom/atom#8514#issuecomment-135127346](https://github.com/atom/atom/pull/8514#issuecomment-135127346).
### In Action
![example](https://cloud.githubusercontent.com/assets/3977054/9509976/a7c09b5e-4c1a-11e5-8763-7dc656ede66c.gif)
The boxes signify lines where there was a leftover indent after a newline command. Once enabling remove trailing whitespace, new lines have their indents set to nothing. Lines with anything besides whitespace will not be effected. The previous line will continue to have it's indent.
### How It Works
Listens to the editor.onDidInsert and then checks to see if the inserted text is a newline. Then proceeds to check if the previous line is blank and decrease the indent if so.
### Note
This should be pretty easy to write a spec for if it is approved as a good change. This pull request was originally made in atom/atom#8514. Moved here because it pertains to whitespace management.