### PR TITLE
Add descriptions for config settings

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -8,7 +8,7 @@ module.exports =
       scopes:
         '.source.jade':
           default: false
-      description: 'Automatically remove whitespace characters at ends of lines when the buffer is saved. To disable/enable for a certain language, use syntax-scoped properties in your `config.cson`. See [the README](https://github.com/atom/whitespace#readme) for more information.'
+      description: 'Automatically remove whitespace characters at ends of lines when the buffer is saved. To disable/enable for a certain language, use [syntax-scoped properties](https://github.com/atom/whitespace#readme) in your `config.cson`.'
     keepMarkdownLineBreakWhitespace:
       type: 'boolean'
       default: true
@@ -16,15 +16,15 @@ module.exports =
     ignoreWhitespaceOnCurrentLine:
       type: 'boolean'
       default: true
-      description: 'Skip removing trailing whitespace on the line which the cursor is positioned on when the buffer is saved. To disable/enable for a certain language, use syntax-scoped properties in your `config.cson`. See [the README](https://github.com/atom/whitespace#readme) for more information.'
+      description: 'Skip removing trailing whitespace on the line which the cursor is positioned on when the buffer is saved. To disable/enable for a certain language, use [syntax-scoped properties](https://github.com/atom/whitespace#readme) in your `config.cson`.'
     ignoreWhitespaceOnlyLines:
       type: 'boolean'
       default: false
-      description: 'Skip removing trailing whitespace on lines which consist only of whitespace characters. To disable/enable for a certain language, use syntax-scoped properties in your `config.cson`. See [the README](https://github.com/atom/whitespace#readme) for more information.'
+      description: 'Skip removing trailing whitespace on lines which consist only of whitespace characters. To disable/enable for a certain language, use [syntax-scoped properties](https://github.com/atom/whitespace#readme) in your `config.cson`.'
     ensureSingleTrailingNewline:
       type: 'boolean'
       default: true
-      description: 'If the buffer doesn\'t end with a newline charcter when it\'s saved, then append one. If the buffer ends with more than one newline character, remove all but one. To disable/enable for a certain language, use syntax-scoped properties in your `config.cson`. See [the README](https://github.com/atom/whitespace#readme) for more information.'
+      description: 'If the buffer doesn\'t end with a newline charcter when it\'s saved, then append one. If it ends with more than one newline, remove all but one. To disable/enable for a certain language, use [syntax-scoped properties](https://github.com/atom/whitespace#readme) in your `config.cson`.'
 
   activate: ->
     @whitespace = new Whitespace()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -8,22 +8,44 @@ module.exports =
       scopes:
         '.source.jade':
           default: false
+      description: '''
+      Automatically remove whitespace characters at ends of lines when the buffer is saved. To
+      disable/enable for a certain language package, you can use syntax-scoped properties in
+      your `config.cson`. See https://github.com/atom/whitespace#readme for more information.
+      '''
     keepMarkdownLineBreakWhitespace:
       type: 'boolean'
       default: true
       description: '''
       Markdown uses two or more spaces at the end of a line to signify a line break. Enable this
-      option to keep this whitespace, even if other settings would remove it.
+      option to keep this whitespace in Markdown files, even if other settings would remove it.
       '''
     ignoreWhitespaceOnCurrentLine:
       type: 'boolean'
       default: true
+      description: '''
+      Skip removing trailing whitespace on the line which the cursor is positioned on when the
+      buffer is saved. To disable/enable for a certain language package, you can use syntax-scoped
+      properties in your `config.cson`. See https://github.com/atom/whitespace#readme for more
+      information.
+      '''
     ignoreWhitespaceOnlyLines:
       type: 'boolean'
       default: false
+      description: '''
+      Skip removing trailing whitespace on lines which consist only of whitespace characters. To
+      disable/enable for a certain language package, you can use syntax-scoped properties in
+      your `config.cson`. See https://github.com/atom/whitespace#readme for more information.
+      '''
     ensureSingleTrailingNewline:
       type: 'boolean'
       default: true
+      description: '''
+      If the buffer doesn't end with a newline charcter when it's saved, then append one. If the
+      buffer ends with more than one newline character, remove all but one. To disable/enable for
+      a certain language package, you can use syntax-scoped properties in your `config.cson`.
+      See https://github.com/atom/whitespace#readme for more information.
+      '''
 
   activate: ->
     @whitespace = new Whitespace()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -8,44 +8,23 @@ module.exports =
       scopes:
         '.source.jade':
           default: false
-      description: '''
-      Automatically remove whitespace characters at ends of lines when the buffer is saved. To
-      disable/enable for a certain language package, you can use syntax-scoped properties in
-      your `config.cson`. See https://github.com/atom/whitespace#readme for more information.
-      '''
+      description: 'Automatically remove whitespace characters at ends of lines when the buffer is saved. To disable/enable for a certain language, use syntax-scoped properties in your `config.cson`. See [the README](https://github.com/atom/whitespace#readme) for more information.'
     keepMarkdownLineBreakWhitespace:
       type: 'boolean'
       default: true
-      description: '''
-      Markdown uses two or more spaces at the end of a line to signify a line break. Enable this
-      option to keep this whitespace in Markdown files, even if other settings would remove it.
-      '''
+      description: 'Markdown uses two or more spaces at the end of a line to signify a line break. Enable this option to keep this whitespace in Markdown files, even if other settings would remove it.'
     ignoreWhitespaceOnCurrentLine:
       type: 'boolean'
       default: true
-      description: '''
-      Skip removing trailing whitespace on the line which the cursor is positioned on when the
-      buffer is saved. To disable/enable for a certain language package, you can use syntax-scoped
-      properties in your `config.cson`. See https://github.com/atom/whitespace#readme for more
-      information.
-      '''
+      description: 'Skip removing trailing whitespace on the line which the cursor is positioned on when the buffer is saved. To disable/enable for a certain language, use syntax-scoped properties in your `config.cson`. See [the README](https://github.com/atom/whitespace#readme) for more information.'
     ignoreWhitespaceOnlyLines:
       type: 'boolean'
       default: false
-      description: '''
-      Skip removing trailing whitespace on lines which consist only of whitespace characters. To
-      disable/enable for a certain language package, you can use syntax-scoped properties in
-      your `config.cson`. See https://github.com/atom/whitespace#readme for more information.
-      '''
+      description: 'Skip removing trailing whitespace on lines which consist only of whitespace characters. To disable/enable for a certain language, use syntax-scoped properties in your `config.cson`. See [the README](https://github.com/atom/whitespace#readme) for more information.'
     ensureSingleTrailingNewline:
       type: 'boolean'
       default: true
-      description: '''
-      If the buffer doesn't end with a newline charcter when it's saved, then append one. If the
-      buffer ends with more than one newline character, remove all but one. To disable/enable for
-      a certain language package, you can use syntax-scoped properties in your `config.cson`.
-      See https://github.com/atom/whitespace#readme for more information.
-      '''
+      description: 'If the buffer doesn\'t end with a newline charcter when it\'s saved, then append one. If the buffer ends with more than one newline character, remove all but one. To disable/enable for a certain language, use syntax-scoped properties in your `config.cson`. See [the README](https://github.com/atom/whitespace#readme) for more information.'
 
   activate: ->
     @whitespace = new Whitespace()


### PR DESCRIPTION
As a followup on https://github.com/atom/atom/pull/9096, this adds descriptions for config settings in this package.

/cc @atom/feedback for :abc: :eyes: 