### PR TITLE
Added a new removeTrailingNewlines option

### DIFF
--- a/lib/whitespace.coffee
+++ b/lib/whitespace.coffee
@@ -28,6 +28,8 @@ class Whitespace
         scopeDescriptor = editor.getRootScopeDescriptor()
         if atom.config.get('whitespace.removeTrailingWhitespace', scope: scopeDescriptor)
           @removeTrailingWhitespace(editor, editor.getGrammar().scopeName)
+        if atom.config.get('whitespace.removeTrailingNewlines', scope: scopeDescriptor)
+          @removeTrailingNewlines(editor)
         if atom.config.get('whitespace.ensureSingleTrailingNewline', scope: scopeDescriptor)
           @ensureSingleTrailingNewline(editor)
 
@@ -74,14 +76,17 @@ class Whitespace
       else
         replace('')
 
+  removeTrailingNewlines: (editor) ->
+    buffer = editor.getBuffer()
+    row = buffer.getLastRow()
+
+    buffer.deleteRow(row--) while row and buffer.lineForRow(row) is ''
+
   ensureSingleTrailingNewline: (editor) ->
     buffer = editor.getBuffer()
     lastRow = buffer.getLastRow()
 
-    if buffer.lineForRow(lastRow) is ''
-      row = lastRow - 1
-      buffer.deleteRow(row--) while row and buffer.lineForRow(row) is ''
-    else
+    if buffer.lineForRow(lastRow) isnt ''
       selectedBufferRanges = editor.getSelectedBufferRanges()
       buffer.append('\n')
       editor.setSelectedBufferRanges(selectedBufferRanges)

--- a/package.json
+++ b/package.json
@@ -41,7 +41,12 @@
     "ensureSingleTrailingNewline": {
       "type": "boolean",
       "default": true,
-      "description": "If the buffer doesn't end with a newline character when it's saved, then append one. If it ends with more than one newline, remove all but one. To disable/enable for a certain language, use [syntax-scoped properties](https://github.com/atom/whitespace#readme) in your `config.cson`."
+      "description": "Ensure that the buffer always ends with exactly one newline character when it's saved. To disable/enable for a certain language, use [syntax-scoped properties](https://github.com/atom/whitespace#readme) in your `config.cson`."
+    },
+    "removeTrailingNewlines": {
+      "type": "boolean",
+      "default": true,
+      "description": "Automatically remove any extra newlines at the end of the buffer when it's saved. To disable/enable for a certain language, use [syntax-scoped properties](https://github.com/atom/whitespace#readme) in your `config.cson`."
     }
   },
   "devDependencies": {

--- a/spec/whitespace-spec.coffee
+++ b/spec/whitespace-spec.coffee
@@ -152,14 +152,10 @@ describe "Whitespace", ->
   describe "when 'whitespace.ensureSingleTrailingNewline' is true", ->
     beforeEach ->
       atom.config.set("whitespace.ensureSingleTrailingNewline", true)
+      atom.config.set("whitespace.removeTrailingNewlines", false)
 
     it "adds a trailing newline when there is no trailing newline", ->
       editor.insertText "foo"
-      editor.save()
-      expect(editor.getText()).toBe "foo\n"
-
-    it "removes extra trailing newlines and only keeps one", ->
-      editor.insertText "foo\n\n\n\n"
       editor.save()
       expect(editor.getText()).toBe "foo\n"
 
@@ -202,6 +198,30 @@ describe "Whitespace", ->
       editor.insertText "no trailing newline"
       editor.save()
       expect(editor.getText()).toBe "no trailing newline"
+
+  describe "when 'whitespace.removeTrailingNewlines' is true", ->
+    beforeEach ->
+      atom.config.set("whitespace.removeTrailingNewlines", true)
+      atom.config.set("whitespace.ensureSingleTrailingNewline", false)
+
+    it "removes extra trailing newlines", ->
+      editor.insertText "foo\n\n\n\n"
+      editor.save()
+      expect(editor.getText()).toBe "foo"
+
+    it "leaves an empty buffer untouched", ->
+      editor.insertText ""
+      editor.save()
+      expect(editor.getText()).toBe ""
+
+  describe "when 'whitespace.removeTrailingNewlines' is false", ->
+    beforeEach ->
+      atom.config.set("whitespace.removeTrailingNewlines", false)
+
+    it "does not remove trailing newlines if removeTrailingNewlines is false", ->
+      editor.insertText "keep trailing newlines\n\n\n"
+      editor.save()
+      expect(editor.getText()).toBe "keep trailing newlines\n\n\n"
 
   describe "GFM whitespace trimming", ->
     describe 'when keepMarkdownLineBreakWhitespace is true', ->


### PR DESCRIPTION
Added a new removeTrailingNewlines option split from the existing ensureSingleTrailingNewline option. By separating the two options we allow users to have more control.

I'm not very familiar with pull requests or Atom packages so please guide me if there is something you would like me to improve.