### PR TITLE
Add commands to save with/without whitespace

### DIFF
--- a/lib/whitespace.coffee
+++ b/lib/whitespace.coffee
@@ -11,6 +11,15 @@ class Whitespace
       'whitespace:remove-trailing-whitespace': =>
         if editor = atom.workspace.getActiveTextEditor()
           @removeTrailingWhitespace(editor, editor.getGrammar().scopeName)
+      'whitespace:save-with-trailing-whitespace': =>
+        if editor = atom.workspace.getActiveTextEditor()
+          @ignore = true
+          editor.save()
+          @ignore = false
+      'whitespace:save-without-trailing-whitespace': =>
+        if editor = atom.workspace.getActiveTextEditor()
+          @removeTrailingWhitespace(editor, editor.getGrammar().scopeName)
+          editor.save()
       'whitespace:convert-tabs-to-spaces': =>
         if editor = atom.workspace.getActiveTextEditor()
           @convertTabsToSpaces(editor)
@@ -26,7 +35,7 @@ class Whitespace
     bufferSavedSubscription = buffer.onWillSave =>
       buffer.transact =>
         scopeDescriptor = editor.getRootScopeDescriptor()
-        if atom.config.get('whitespace.removeTrailingWhitespace', scope: scopeDescriptor)
+        if atom.config.get('whitespace.removeTrailingWhitespace', scope: scopeDescriptor) and not @ignore
           @removeTrailingWhitespace(editor, editor.getGrammar().scopeName)
         if atom.config.get('whitespace.ensureSingleTrailingNewline', scope: scopeDescriptor)
           @ensureSingleTrailingNewline(editor)

--- a/menus/whitespace.cson
+++ b/menus/whitespace.cson
@@ -5,6 +5,8 @@
       'label': 'Whitespace'
       'submenu': [
         { 'label': 'Remove Trailing Whitespace', 'command': 'whitespace:remove-trailing-whitespace' }
+        { 'label': 'Save With Trailing Whitespace', 'command': 'whitespace:save-with-trailing-whitespace' }
+        { 'label': 'Save Without Trailing Whitespace', 'command': 'whitespace:save-without-trailing-whitespace' }
         { 'label': 'Convert Tabs To Spaces', 'command': 'whitespace:convert-tabs-to-spaces' }
         { 'label': 'Convert Spaces To Tabs', 'command': 'whitespace:convert-spaces-to-tabs' }
       ]

--- a/spec/whitespace-spec.coffee
+++ b/spec/whitespace-spec.coffee
@@ -345,6 +345,28 @@ describe "Whitespace", ->
       atom.packages.deactivatePackage 'whitespace'
       expect(buffer.getText()).toBe "foo   \nbar\t   \n\nbaz"
 
+  describe "when the 'whitespace:save-with-trailing-whitespace' command is run", ->
+    beforeEach ->
+      atom.config.set("whitespace.removeTrailingWhitespace", true)
+      atom.config.set("whitespace.ensureSingleTrailingNewline", false)
+      buffer.setText("foo   \nbar\t   \n\nbaz")
+
+    it "saves the file without removing any trailing whitespace", ->
+      atom.commands.dispatch(workspaceElement, 'whitespace:save-with-trailing-whitespace')
+      expect(buffer.getText()).toBe "foo   \nbar\t   \n\nbaz"
+      expect(buffer.isModified()).toBe false
+
+  describe "when the 'whitespace:save-without-trailing-whitespace' command is run", ->
+    beforeEach ->
+      atom.config.set("whitespace.removeTrailingWhitespace", false)
+      atom.config.set("whitespace.ensureSingleTrailingNewline", false)
+      buffer.setText("foo   \nbar\t   \n\nbaz")
+
+    it "saves the file and removes any trailing whitespace", ->
+      atom.commands.dispatch(workspaceElement, 'whitespace:save-without-trailing-whitespace')
+      expect(buffer.getText()).toBe "foo\nbar\n\nbaz"
+      expect(buffer.isModified()).toBe false
+
   describe "when the 'whitespace:convert-tabs-to-spaces' command is run", ->
     it "removes all \t characters and replaces them with spaces using the configured tab length", ->
       editor.setTabLength(2)


### PR DESCRIPTION
* `whitespace:save-with-trailing-whitespace` will save the file while keeping all trailing whitespace intact
* `whitespace:save-without-trailing-whitespace` will save the file and remove any trailing whitespace (in accordance with the other config options)

Both commands ignore the `whitespace.removeTrailingWhitespace` setting but respect all others.

Closes #117
Supersedes and closes #66
Closes #11
Refs #65