### PR TITLE
Alter commands to limit conversion to leading whitespace

### DIFF
--- a/lib/whitespace.coffee
+++ b/lib/whitespace.coffee
@@ -17,6 +17,9 @@ class Whitespace
       'whitespace:convert-spaces-to-tabs': =>
         if editor = atom.workspace.getActiveTextEditor()
           @convertSpacesToTabs(editor)
+      'whitespace:convert-all-spaces-to-tabs': =>
+        if editor = atom.workspace.getActiveTextEditor()
+          @convertSpacesToTabs(editor, true)
 
   destroy: ->
     @subscriptions.dispose()
@@ -95,14 +98,14 @@ class Whitespace
 
     editor.setSoftTabs(true)
 
-  convertSpacesToTabs: (editor) ->
+  convertSpacesToTabs: (editor, convertAllSpaces) ->
     buffer = editor.getBuffer()
     scope = editor.getRootScopeDescriptor()
     fileTabSize = editor.getTabLength()
     userTabSize = atom.config.get 'editor.tabLength', {scope}
     regex = new RegExp ' '.repeat(fileTabSize), 'g'
 
-    if atom.config.get 'whitespace.convertLeadingSpacesOnly', {scope}
+    unless convertAllSpaces
       buffer.transact ->
         buffer.scan /^[ \t]+/g, ({matchText, replace}) ->
           replace matchText.replace(regex, "\t").replace(/[ ]+\t/g, "\t")

--- a/lib/whitespace.coffee
+++ b/lib/whitespace.coffee
@@ -97,9 +97,19 @@ class Whitespace
 
   convertSpacesToTabs: (editor) ->
     buffer = editor.getBuffer()
-    spacesText = new Array(editor.getTabLength() + 1).join(' ')
+    tabSize = editor.getTabLength()
+    scope = editor.getRootScopeDescriptor()
+
+    if atom.config.get 'whitespace.convertLeadingSpacesOnly', {scope}
+      regex = new RegExp '^(?: {' + tabSize + '})+', 'g'
+      iterator = ({matchText, replace}) ->
+        replace '\t'.repeat(matchText.length / tabSize)
+
+    else
+      regex = new RegExp ' '.repeat(tabSize), 'g'
+      iterator = ({replace}) -> replace('\t')
 
     buffer.transact ->
-      buffer.scan new RegExp(spacesText, 'g'), ({replace}) -> replace('\t')
+      buffer.scan regex, iterator
 
     editor.setSoftTabs(false)

--- a/lib/whitespace.coffee
+++ b/lib/whitespace.coffee
@@ -89,7 +89,7 @@ class Whitespace
   convertTabsToSpaces: (editor) ->
     buffer = editor.getBuffer()
     spacesText = new Array(editor.getTabLength() + 1).join(' ')
-	
+
     buffer.transact ->
       buffer.scan /\t/g, ({replace}) -> replace(spacesText)
 
@@ -100,18 +100,16 @@ class Whitespace
     scope = editor.getRootScopeDescriptor()
     fileTabSize = editor.getTabLength()
     userTabSize = atom.config.get 'editor.tabLength', {scope}
+    regex = new RegExp ' '.repeat(fileTabSize), 'g'
 
     if atom.config.get 'whitespace.convertLeadingSpacesOnly', {scope}
-      regex = new RegExp '^(?: {' + fileTabSize + '})+', 'g'
-      iterator = ({matchText, replace}) ->
-        replace '\t'.repeat(matchText.length / fileTabSize)
+      buffer.transact ->
+        buffer.scan /^[ \t]+/g, ({matchText, replace}) ->
+          replace matchText.replace(regex, "\t").replace(/[ ]+\t/g, "\t")
 
     else
-      regex = new RegExp ' '.repeat(fileTabSize), 'g'
-      iterator = ({replace}) -> replace('\t')
-
-    buffer.transact ->
-      buffer.scan regex, iterator
+      buffer.transact ->
+        buffer.scan regex, ({replace}) -> replace('\t')
 
     editor.setSoftTabs(false)
     editor.setTabLength(userTabSize) unless fileTabSize is userTabSize

--- a/lib/whitespace.coffee
+++ b/lib/whitespace.coffee
@@ -89,7 +89,7 @@ class Whitespace
   convertTabsToSpaces: (editor) ->
     buffer = editor.getBuffer()
     spacesText = new Array(editor.getTabLength() + 1).join(' ')
-
+	
     buffer.transact ->
       buffer.scan /\t/g, ({replace}) -> replace(spacesText)
 
@@ -97,19 +97,21 @@ class Whitespace
 
   convertSpacesToTabs: (editor) ->
     buffer = editor.getBuffer()
-    tabSize = editor.getTabLength()
     scope = editor.getRootScopeDescriptor()
+    fileTabSize = editor.getTabLength()
+    userTabSize = atom.config.get 'editor.tabLength', {scope}
 
     if atom.config.get 'whitespace.convertLeadingSpacesOnly', {scope}
-      regex = new RegExp '^(?: {' + tabSize + '})+', 'g'
+      regex = new RegExp '^(?: {' + fileTabSize + '})+', 'g'
       iterator = ({matchText, replace}) ->
-        replace '\t'.repeat(matchText.length / tabSize)
+        replace '\t'.repeat(matchText.length / fileTabSize)
 
     else
-      regex = new RegExp ' '.repeat(tabSize), 'g'
+      regex = new RegExp ' '.repeat(fileTabSize), 'g'
       iterator = ({replace}) -> replace('\t')
 
     buffer.transact ->
       buffer.scan regex, iterator
 
     editor.setSoftTabs(false)
+    editor.setTabLength(userTabSize) unless fileTabSize is userTabSize

--- a/menus/whitespace.cson
+++ b/menus/whitespace.cson
@@ -7,6 +7,7 @@
         { 'label': 'Remove Trailing Whitespace', 'command': 'whitespace:remove-trailing-whitespace' }
         { 'label': 'Convert Tabs To Spaces', 'command': 'whitespace:convert-tabs-to-spaces' }
         { 'label': 'Convert Spaces To Tabs', 'command': 'whitespace:convert-spaces-to-tabs' }
+        { 'label': 'Convert All Tabs To Spaces', 'command': 'whitespace:convert-all-tabs-to-spaces' }
       ]
     ]
   }

--- a/package.json
+++ b/package.json
@@ -38,11 +38,6 @@
       "default": false,
       "description": "Skip removing trailing whitespace on lines which consist only of whitespace characters. To disable/enable for a certain language, use [syntax-scoped properties](https://github.com/atom/whitespace#readme) in your `config.cson`."
     },
-    "convertLeadingSpacesOnly": {
-      "type": "boolean",
-      "default": true,
-      "description": "When converting spaces to tabs, only convert spaces used before a non-whitespace character."
-    },
     "ensureSingleTrailingNewline": {
       "type": "boolean",
       "default": true,

--- a/package.json
+++ b/package.json
@@ -38,6 +38,11 @@
       "default": false,
       "description": "Skip removing trailing whitespace on lines which consist only of whitespace characters. To disable/enable for a certain language, use [syntax-scoped properties](https://github.com/atom/whitespace#readme) in your `config.cson`."
     },
+    "convertLeadingSpacesOnly": {
+      "type": "boolean",
+      "default": true,
+      "description": "When converting spaces to tabs, only convert spaces used before a non-whitespace character."
+    },
     "ensureSingleTrailingNewline": {
       "type": "boolean",
       "default": true,

--- a/spec/whitespace-spec.coffee
+++ b/spec/whitespace-spec.coffee
@@ -346,16 +346,16 @@ describe "Whitespace", ->
       expect(buffer.getText()).toBe "foo   \nbar\t   \n\nbaz"
 
   describe "when the 'whitespace:convert-tabs-to-spaces' command is run", ->
-    it "removes all \t characters and replaces them with spaces using the configured tab length", ->
+    it "removes leading \\t characters and replaces them with spaces using the configured tab length", ->
       editor.setTabLength(2)
       buffer.setText('\ta\n\t\nb\t\nc\t\td')
       atom.commands.dispatch(workspaceElement, 'whitespace:convert-tabs-to-spaces')
-      expect(buffer.getText()).toBe "  a\n  \nb  \nc    d"
+      expect(buffer.getText()).toBe "  a\n  \nb\t\nc\t\td"
 
       editor.setTabLength(3)
       buffer.setText('\ta\n\t\nb\t\nc\t\td')
       atom.commands.dispatch(workspaceElement, 'whitespace:convert-tabs-to-spaces')
-      expect(buffer.getText()).toBe "   a\n   \nb   \nc      d"
+      expect(buffer.getText()).toBe "   a\n   \nb\t\nc\t\td"
 
     it "changes the tab type to soft tabs", ->
       atom.commands.dispatch(workspaceElement, 'whitespace:convert-tabs-to-spaces')
@@ -389,35 +389,18 @@ describe "Whitespace", ->
       atom.commands.dispatch(workspaceElement, 'whitespace:convert-spaces-to-tabs')
       expect(editor.getTabLength()).toBe 2
 
-  describe "when the 'whitespace:convert-all-spaces-to-tabs' command is run", ->
-    it "replaces all space characters with hard tabs", ->
+  describe "when the 'whitespace:convert-all-tabs-to-spaces' command is run", ->
+    it "removes all \\t characters and replaces them with spaces using the configured tab length", ->
       editor.setTabLength(2)
-      buffer.setText("   a\n  \nb  \nc    d")
-      atom.commands.dispatch(workspaceElement, 'whitespace:convert-all-spaces-to-tabs')
-      expect(buffer.getText()).toBe '\t a\n\t\nb\t\nc\t\td'
+      buffer.setText('\ta\n\t\nb\t\nc\t\td')
+      atom.commands.dispatch(workspaceElement, 'whitespace:convert-all-tabs-to-spaces')
+      expect(buffer.getText()).toBe "  a\n  \nb  \nc    d"
 
       editor.setTabLength(3)
-      buffer.setText("     a\n   \nb   \nc      d")
-      atom.commands.dispatch(workspaceElement, 'whitespace:convert-all-spaces-to-tabs')
-      expect(buffer.getText()).toBe '\t  a\n\t\nb\t\nc\t\td'
+      buffer.setText('\ta\n\t\nb\t\nc\t\td')
+      atom.commands.dispatch(workspaceElement, 'whitespace:convert-all-tabs-to-spaces')
+      expect(buffer.getText()).toBe "   a\n   \nb   \nc      d"
 
-    it "handles mixed runs of tabs and spaces correctly", ->
-      editor.setTabLength(4)
-      buffer.setText("     \t    \t\ta   ")
-      atom.commands.dispatch(workspaceElement, 'whitespace:convert-all-spaces-to-tabs')
-      expect(buffer.getText()).toBe "\t \t\t\t\ta   "
-
-      editor.setTabLength(3)
-      buffer.setText("     \t   \t\ta    ")
-      atom.commands.dispatch(workspaceElement, 'whitespace:convert-all-spaces-to-tabs')
-      expect(buffer.getText()).toBe "\t  \t\t\t\ta\t "
-
-    it "changes the tab type to hard tabs", ->
-      atom.commands.dispatch(workspaceElement, 'whitespace:convert-all-spaces-to-tabs')
-      expect(editor.getSoftTabs()).toBe false
-
-    it "changes the tab length to user's tab-size", ->
-      editor.setTabLength(4)
-      buffer.setText("    ")
-      atom.commands.dispatch(workspaceElement, 'whitespace:convert-all-spaces-to-tabs')
-      expect(editor.getTabLength()).toBe 2
+    it "changes the tab type to soft tabs", ->
+      atom.commands.dispatch(workspaceElement, 'whitespace:convert-all-tabs-to-spaces')
+      expect(editor.getSoftTabs()).toBe true

--- a/spec/whitespace-spec.coffee
+++ b/spec/whitespace-spec.coffee
@@ -379,18 +379,6 @@ describe "Whitespace", ->
       atom.commands.dispatch(workspaceElement, 'whitespace:convert-spaces-to-tabs')
       expect(buffer.getText()).toBe "\t\t\t\t\ta   "
 
-    it "replaces all space characters with hard tabs when convertLeadingSpacesOnly is disabled", ->
-      atom.config.set 'whitespace.convertLeadingSpacesOnly', false
-      editor.setTabLength(2)
-      buffer.setText("   a\n  \nb  \nc    d")
-      atom.commands.dispatch(workspaceElement, 'whitespace:convert-spaces-to-tabs')
-      expect(buffer.getText()).toBe '\t a\n\t\nb\t\nc\t\td'
-
-      editor.setTabLength(3)
-      buffer.setText("     a\n   \nb   \nc      d")
-      atom.commands.dispatch(workspaceElement, 'whitespace:convert-spaces-to-tabs')
-      expect(buffer.getText()).toBe '\t  a\n\t\nb\t\nc\t\td'
-
     it "changes the tab type to hard tabs", ->
       atom.commands.dispatch(workspaceElement, 'whitespace:convert-spaces-to-tabs')
       expect(editor.getSoftTabs()).toBe false
@@ -400,3 +388,15 @@ describe "Whitespace", ->
       buffer.setText("    ")
       atom.commands.dispatch(workspaceElement, 'whitespace:convert-spaces-to-tabs')
       expect(editor.getTabLength()).toBe 2
+
+  describe "when the 'whitespace:convert-all-spaces-to-tabs' command is run", ->
+    it "replaces all space characters with hard tabs", ->
+      editor.setTabLength(2)
+      buffer.setText("   a\n  \nb  \nc    d")
+      atom.commands.dispatch(workspaceElement, 'whitespace:convert-all-spaces-to-tabs')
+      expect(buffer.getText()).toBe '\t a\n\t\nb\t\nc\t\td'
+
+      editor.setTabLength(3)
+      buffer.setText("     a\n   \nb   \nc      d")
+      atom.commands.dispatch(workspaceElement, 'whitespace:convert-all-spaces-to-tabs')
+      expect(buffer.getText()).toBe '\t  a\n\t\nb\t\nc\t\td'

--- a/spec/whitespace-spec.coffee
+++ b/spec/whitespace-spec.coffee
@@ -400,3 +400,24 @@ describe "Whitespace", ->
       buffer.setText("     a\n   \nb   \nc      d")
       atom.commands.dispatch(workspaceElement, 'whitespace:convert-all-spaces-to-tabs')
       expect(buffer.getText()).toBe '\t  a\n\t\nb\t\nc\t\td'
+
+    it "handles mixed runs of tabs and spaces correctly", ->
+      editor.setTabLength(4)
+      buffer.setText("     \t    \t\ta   ")
+      atom.commands.dispatch(workspaceElement, 'whitespace:convert-all-spaces-to-tabs')
+      expect(buffer.getText()).toBe "\t \t\t\t\ta   "
+
+      editor.setTabLength(3)
+      buffer.setText("     \t   \t\ta    ")
+      atom.commands.dispatch(workspaceElement, 'whitespace:convert-all-spaces-to-tabs')
+      expect(buffer.getText()).toBe "\t  \t\t\t\ta\t "
+
+    it "changes the tab type to hard tabs", ->
+      atom.commands.dispatch(workspaceElement, 'whitespace:convert-all-spaces-to-tabs')
+      expect(editor.getSoftTabs()).toBe false
+
+    it "changes the tab length to user's tab-size", ->
+      editor.setTabLength(4)
+      buffer.setText("    ")
+      atom.commands.dispatch(workspaceElement, 'whitespace:convert-all-spaces-to-tabs')
+      expect(editor.getTabLength()).toBe 2

--- a/spec/whitespace-spec.coffee
+++ b/spec/whitespace-spec.coffee
@@ -372,14 +372,20 @@ describe "Whitespace", ->
       buffer.setText("     a\n   \nb   \nc      d")
       atom.commands.dispatch(workspaceElement, 'whitespace:convert-spaces-to-tabs')
       expect(buffer.getText()).toBe '\t  a\n\t\nb   \nc      d'
-    
+
+    it "handles mixed runs of tabs and spaces correctly", ->
+      editor.setTabLength(4)
+      buffer.setText("     \t    \t\ta   ")
+      atom.commands.dispatch(workspaceElement, 'whitespace:convert-spaces-to-tabs')
+      expect(buffer.getText()).toBe "\t\t\t\t\ta   "
+
     it "replaces all space characters with hard tabs when convertLeadingSpacesOnly is disabled", ->
       atom.config.set 'whitespace.convertLeadingSpacesOnly', false
       editor.setTabLength(2)
       buffer.setText("   a\n  \nb  \nc    d")
       atom.commands.dispatch(workspaceElement, 'whitespace:convert-spaces-to-tabs')
       expect(buffer.getText()).toBe '\t a\n\t\nb\t\nc\t\td'
-      
+
       editor.setTabLength(3)
       buffer.setText("     a\n   \nb   \nc      d")
       atom.commands.dispatch(workspaceElement, 'whitespace:convert-spaces-to-tabs')

--- a/spec/whitespace-spec.coffee
+++ b/spec/whitespace-spec.coffee
@@ -362,17 +362,35 @@ describe "Whitespace", ->
       expect(editor.getSoftTabs()).toBe true
 
   describe "when the 'whitespace:convert-spaces-to-tabs' command is run", ->
-    it "removes all space characters and replaces them with hard tabs", ->
+    it "removes leading space characters and replaces them with hard tabs", ->
       editor.setTabLength(2)
-      buffer.setText("  a\n  \nb  \nc    d")
+      buffer.setText("   a\n  \nb  \nc    d")
       atom.commands.dispatch(workspaceElement, 'whitespace:convert-spaces-to-tabs')
-      expect(buffer.getText()).toBe '\ta\n\t\nb\t\nc\t\td'
+      expect(buffer.getText()).toBe '\t a\n\t\nb  \nc    d'
 
       editor.setTabLength(3)
-      buffer.setText("   a\n   \nb   \nc      d"
+      buffer.setText("     a\n   \nb   \nc      d")
       atom.commands.dispatch(workspaceElement, 'whitespace:convert-spaces-to-tabs')
-      expect(buffer.getText()).toBe '\ta\n\t\nb\t\nc\t\td')
+      expect(buffer.getText()).toBe '\t  a\n\t\nb   \nc      d'
+    
+    it "replaces all space characters with hard tabs when convertLeadingSpacesOnly is disabled", ->
+      atom.config.set 'whitespace.convertLeadingSpacesOnly', false
+      editor.setTabLength(2)
+      buffer.setText("   a\n  \nb  \nc    d")
+      atom.commands.dispatch(workspaceElement, 'whitespace:convert-spaces-to-tabs')
+      expect(buffer.getText()).toBe '\t a\n\t\nb\t\nc\t\td'
+      
+      editor.setTabLength(3)
+      buffer.setText("     a\n   \nb   \nc      d")
+      atom.commands.dispatch(workspaceElement, 'whitespace:convert-spaces-to-tabs')
+      expect(buffer.getText()).toBe '\t  a\n\t\nb\t\nc\t\td'
 
     it "changes the tab type to hard tabs", ->
       atom.commands.dispatch(workspaceElement, 'whitespace:convert-spaces-to-tabs')
       expect(editor.getSoftTabs()).toBe false
+
+    it "changes the tab length to user's tab-size", ->
+      editor.setTabLength(4)
+      buffer.setText("    ")
+      atom.commands.dispatch(workspaceElement, 'whitespace:convert-spaces-to-tabs')
+      expect(editor.getTabLength()).toBe 2


### PR DESCRIPTION
Fixes #75. It's enabled by default, as I think users would expect only leading spaces to be affected by the conversion (and if they don't, they should... tabs should *never* be used after a non-whitespace character in code).

It also resolves another issue of the editor's tab-length not being set to the user's after a space-to-tab conversion. Until now, I've been forced to save, close and reopen a converted file in order to view it properly (I commonly do this...)