### PR TITLE
Optimize removeTrailingWhitespace function

### DIFF
--- a/lib/whitespace.js
+++ b/lib/whitespace.js
@@ -1,6 +1,8 @@
 /** @babel */
 
-import {CompositeDisposable} from 'atom'
+import {CompositeDisposable, Point, Range} from 'atom'
+
+const TRAILING_WHITESPACE_REGEX = /[ \t]+$/g
 
 export default class Whitespace {
   constructor () {
@@ -124,40 +126,36 @@ export default class Whitespace {
   }
 
   removeTrailingWhitespace (editor, grammarScopeName) {
-    let buffer = editor.getBuffer()
-    let scopeDescriptor = editor.getRootScopeDescriptor()
+    const buffer = editor.getBuffer()
+    const scopeDescriptor = editor.getRootScopeDescriptor()
+    const cursorRows = new Set(editor.getCursors().map(cursor => cursor.getBufferRow()))
 
-    let ignoreCurrentLine = atom.config.get('whitespace.ignoreWhitespaceOnCurrentLine', {
+    const ignoreCurrentLine = atom.config.get('whitespace.ignoreWhitespaceOnCurrentLine', {
       scope: scopeDescriptor
     })
 
-    let ignoreWhitespaceOnlyLines = atom.config.get('whitespace.ignoreWhitespaceOnlyLines', {
+    const ignoreWhitespaceOnlyLines = atom.config.get('whitespace.ignoreWhitespaceOnlyLines', {
       scope: scopeDescriptor
     })
 
-    return buffer.backwardsScan(/[ \t]+$/g, function ({lineText, match, replace}) {
-      let whitespaceRow = buffer.positionForCharacterIndex(match.index).row
+    const keepMarkdownLineBreakWhitespace =
+      grammarScopeName === 'source.gfm' &&
+      atom.config.get('whitespace.keepMarkdownLineBreakWhitespace')
 
-      let cursorRows = editor.getCursors().map(cursor => {
-        return cursor.getBufferRow()
-      })
-
-      if (ignoreCurrentLine && cursorRows.includes(whitespaceRow)) {
-        return
-      }
-
-      let [whitespace] = match
-
-      if (ignoreWhitespaceOnlyLines && whitespace === lineText) {
-        return
-      }
-
-      if (grammarScopeName === 'source.gfm' && atom.config.get('whitespace.keepMarkdownLineBreakWhitespace')) {
-        if (!(whitespace.length >= 2 && whitespace !== lineText)) {
-          return replace('')
+    buffer.transact(() => {
+      for (let row = 0, lineCount = buffer.getLineCount(); row < lineCount; row++) {
+        const line = buffer.lineForRow(row)
+        const lastCharacter = line[line.length - 1]
+        if (lastCharacter === ' ' || lastCharacter === '\t') {
+          const trailingWhitespaceStart = line.search(TRAILING_WHITESPACE_REGEX)
+          if (ignoreCurrentLine && cursorRows.has(row)) continue
+          if (ignoreWhitespaceOnlyLines && trailingWhitespaceStart === 0) continue
+          if (keepMarkdownLineBreakWhitespace) {
+            const whitespaceLength = line.length - trailingWhitespaceStart
+            if (trailingWhitespaceStart > 0 && whitespaceLength >= 2) continue
+          }
+          buffer.delete(Range(Point(row, trailingWhitespaceStart), Point(row, line.length)))
         }
-      } else {
-        return replace('')
       }
     })
   }


### PR DESCRIPTION
This code was very inefficient; it caused saving a large file to take forever, even if there was no trailing whitespace.

🍐 'd with @nathansobo

/cc @ungb @Ben3eeE 