### PR TITLE
Leave trailing whitespace for source.diff, source.patch and source.pug grammars.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ To disable/enable features for a certain language package, you can use syntax-sc
 
 You find the `scope` on top of a grammar package's settings view.
 
-Note: for `.source.jade` removing trailing whitespace is disabled by default.
+Note: for `.source.jade`, `.source.diff`, `.source.pug` and `.source.patch`, removing trailing whitespace is disabled by default.

--- a/package.json
+++ b/package.json
@@ -45,7 +45,13 @@
       "type": "boolean",
       "default": true,
       "scopes": {
+        ".source.diff": {
+          "default": false
+        },
         ".source.jade": {
+          "default": false
+        },
+        ".source.patch": {
           "default": false
         }
       },

--- a/package.json
+++ b/package.json
@@ -53,6 +53,9 @@
         },
         ".source.patch": {
           "default": false
+        },
+        ".source.pug": {
+          "default": false
         }
       },
       "description": "Automatically remove whitespace characters at ends of lines when the buffer is saved. To disable/enable for a certain language, use [syntax-scoped properties](https://github.com/atom/whitespace#readme) in your `config.cson`."


### PR DESCRIPTION
### Description of the Change

Automatically removing whitespace for diff and patch files breaks them.  As an example, empty lines in a patch are signified by a single space, so having this plugin strip that single space makes the patch have invalid syntax, resulting in an error when trying to apply it.  This applies to what look like the top two patch language support plugins that I could see, language-diff and language-patch.

### Alternate Designs

This can be done by the user, on a grammar-by-grammar basis, but really stripping whitespace on patch files by default makes no sense.

### Benefits

Users making manual edits to patch and diff files will no longer be surprised that their patch files have become invalid.

### Possible Drawbacks

I can't think of any.

### Applicable Issues

None.
