### PR TITLE
Don't assume that save is synchronous in specs

### DIFF
--- a/spec/whitespace-spec.coffee
+++ b/spec/whitespace-spec.coffee
@@ -347,9 +347,12 @@ describe "Whitespace", ->
       buffer.setText("foo   \nbar\t   \n\nbaz")
 
     it "saves the file without removing any trailing whitespace", ->
-      atom.commands.dispatch(workspaceElement, 'whitespace:save-with-trailing-whitespace')
-      expect(buffer.getText()).toBe "foo   \nbar\t   \n\nbaz"
-      expect(buffer.isModified()).toBe false
+      waitsFor (done) ->
+        buffer.onDidSave ->
+          expect(buffer.getText()).toBe "foo   \nbar\t   \n\nbaz"
+          expect(buffer.isModified()).toBe false
+          done()
+        atom.commands.dispatch(workspaceElement, 'whitespace:save-with-trailing-whitespace')
 
   describe "when the 'whitespace:save-without-trailing-whitespace' command is run", ->
     beforeEach ->
@@ -358,9 +361,12 @@ describe "Whitespace", ->
       buffer.setText("foo   \nbar\t   \n\nbaz")
 
     it "saves the file and removes any trailing whitespace", ->
-      atom.commands.dispatch(workspaceElement, 'whitespace:save-without-trailing-whitespace')
-      expect(buffer.getText()).toBe "foo\nbar\n\nbaz"
-      expect(buffer.isModified()).toBe false
+      waitsFor (done) ->
+        buffer.onDidSave ->
+          expect(buffer.getText()).toBe "foo\nbar\n\nbaz"
+          expect(buffer.isModified()).toBe false
+          done()
+        atom.commands.dispatch(workspaceElement, 'whitespace:save-without-trailing-whitespace')
 
   describe "when the 'whitespace:convert-tabs-to-spaces' command is run", ->
     it "removes leading \\t characters and replaces them with spaces using the configured tab length", ->


### PR DESCRIPTION
The `TextBuffer.save` method is going to become async in atom/atom#14435; instead of doing a synchronous write, it will initiate an asynchronous write and return a promise when the write completes. This shouldn't affect the user-facing functionality of many packages; but several packages may have test failures.

This PR updates the two tests in `whitespace` that broke due to this change, so that they work regardless of whether save is synchronous or asynchronous.