### PR TITLE
Fix trailing whitespace removal w/ CRLF line endings

### DIFF
--- a/lib/whitespace.js
+++ b/lib/whitespace.js
@@ -2,7 +2,7 @@
 
 import {CompositeDisposable, Point, Range} from 'atom'
 
-const TRAILING_WHITESPACE_REGEX = /[ \t]+$/g
+const TRAILING_WHITESPACE_REGEX = /[ \t]+(?=\r?$)/g
 
 export default class Whitespace {
   constructor () {

--- a/spec/whitespace-spec.coffee
+++ b/spec/whitespace-spec.coffee
@@ -57,6 +57,11 @@ describe "Whitespace", ->
         editor.save()
         expect(editor.getText()).toBe 'Some text.\n'
 
+    it "works for files with CRLF line endings", ->
+      editor.insertText("foo   \r\nbar\t   \r\n\r\nbaz\r\n")
+      editor.save()
+      expect(editor.getText()).toBe "foo\r\nbar\r\n\r\nbaz\r\n"
+
     it "clears blank lines when the editor inserts a newline", ->
       # Need autoIndent to be true
       atom.config.set 'editor.autoIndent', true


### PR DESCRIPTION
When searching the entire file's text (as opposed to a single line's), the previous regex didn't match lines that ended with CRLF.

Fixes #158