### PR TITLE
Don't watch editors more than once if they're re-added to the workspace

### DIFF
--- a/lib/whitespace.js
+++ b/lib/whitespace.js
@@ -4,6 +4,7 @@ const TRAILING_WHITESPACE_REGEX = /[ \t]+(?=\r?$)/g
 
 module.exports = class Whitespace {
   constructor () {
+    this.watchedEditors = new WeakSet()
     this.subscriptions = new CompositeDisposable()
 
     this.subscriptions.add(atom.workspace.observeTextEditors(editor => {
@@ -69,6 +70,8 @@ module.exports = class Whitespace {
   }
 
   handleEvents (editor) {
+    if (this.watchedEditors.has(editor)) return
+
     let buffer = editor.getBuffer()
 
     let bufferSavedSubscription = buffer.onWillSave(() => {
@@ -116,11 +119,13 @@ module.exports = class Whitespace {
       this.subscriptions.remove(bufferSavedSubscription)
       this.subscriptions.remove(editorTextInsertedSubscription)
       this.subscriptions.remove(editorDestroyedSubscription)
+      this.watchedEditors.delete(editor)
     })
 
     this.subscriptions.add(bufferSavedSubscription)
     this.subscriptions.add(editorTextInsertedSubscription)
     this.subscriptions.add(editorDestroyedSubscription)
+    this.watchedEditors.add(editor)
   }
 
   removeTrailingWhitespace (editor, grammarScopeName) {


### PR DESCRIPTION
This will prevent this package from providing its functionality to editors more than once in case they get added to the workspace, then removed from it and finally added back.

/cc: @nathansobo @jasonrudolph