### PR TITLE
Tune behavior of ignore whitespace on current line

### DIFF
--- a/lib/whitespace.js
+++ b/lib/whitespace.js
@@ -131,7 +131,12 @@ module.exports = class Whitespace {
   removeTrailingWhitespace (editor, grammarScopeName) {
     const buffer = editor.getBuffer()
     const scopeDescriptor = editor.getRootScopeDescriptor()
-    const cursorRows = new Set(editor.getCursors().map(cursor => cursor.getBufferRow()))
+
+    // When buffer is same buffer of activeEditor's buffer, don't remove
+    // trailing WS at activeEditor's cursor line.
+    const activeEditor = atom.workspace.getActiveTextEditor()
+    const cursors = activeEditor.getBuffer() === buffer ? activeEditor.getCursors() : []
+    const cursorRows = new Set(cursors.map(cursor => cursor.getBufferRow()))
 
     const ignoreCurrentLine = atom.config.get('whitespace.ignoreWhitespaceOnCurrentLine', {
       scope: scopeDescriptor

--- a/lib/whitespace.js
+++ b/lib/whitespace.js
@@ -135,8 +135,10 @@ module.exports = class Whitespace {
     // When buffer is same buffer of activeEditor's buffer, don't remove
     // trailing WS at activeEditor's cursor line.
     const activeEditor = atom.workspace.getActiveTextEditor()
-    const cursors = activeEditor.getBuffer() === buffer ? activeEditor.getCursors() : []
-    const cursorRows = new Set(cursors.map(cursor => cursor.getBufferRow()))
+    const cursorRows =
+      activeEditor && activeEditor.getBuffer() === buffer
+        ? new Set(activeEditor.getCursors().map(cursor => cursor.getBufferRow()))
+        : new Set()
 
     const ignoreCurrentLine = atom.config.get('whitespace.ignoreWhitespaceOnCurrentLine', {
       scope: scopeDescriptor

--- a/spec/whitespace-spec.js
+++ b/spec/whitespace-spec.js
@@ -109,17 +109,17 @@ describe('Whitespace', () => {
   describe("when 'whitespace.ignoreWhitespaceOnCurrentLine' is true", () => {
     beforeEach(() => atom.config.set('whitespace.ignoreWhitespaceOnCurrentLine', true))
 
-    describe("respects multiple cursors", () => {
-      it("removes the whitespace from all lines, excluding the current lines", async () => {
-        editor.insertText("1  \n2  \n3  \n")
+    describe('respects multiple cursors', () => {
+      it('removes the whitespace from all lines, excluding the current lines', async () => {
+        editor.insertText('1  \n2  \n3  \n')
         editor.setCursorBufferPosition([1, 3])
         editor.addCursorAtBufferPosition([2, 3])
         await editor.save()
-        expect(editor.getText()).toBe("1\n2  \n3  \n")
+        expect(editor.getText()).toBe('1\n2  \n3  \n')
       })
     })
 
-    describe("when buffer is opened in multiple editors", () => {
+    describe('when buffer is opened in multiple editors', () => {
       let editor2
       beforeEach(async () => {
         editor2 = atom.workspace.buildTextEditor({buffer: editor.buffer})


### PR DESCRIPTION
### Requirements

Fix #76

### Description of the Change

Previously `ignoreWhitespaceOnCurrentLine` was not appropriately respected when one buffer is opened in multiple editors.
This PR improve behavior of `ignoreWhitespaceOnCurrentLine` how most user expect(I believe so).

In case test case's intention was not clear, see following illustration what happens on save.

#### Condition

When two editor open same file. Two editor shares same buffer.

- `|` represent cursor
- `_` represent trailing white spaces
- editor1 have cursor at 1st line
- editor2 have cursor at 2nd line

```
+-------------------------+-------------------------+
| editor1                 | editor2                 |
+-------------------------+-------------------------+
| line1____|              | line1____               |
| line2____               | line2____|              |
| line3                   | line3                   |
|                         |                         |
+-------------------------+-------------------------+
```

#### case 1: saved when editor1 is active

result: editor1's cursor line was excluded

```
+-------------------------+-------------------------+
| editor1(active)         | editor2                 |
+-------------------------+-------------------------+
| line1____|              | line1____               |
| line2                   | line2|                  |
| line3                   | line3                   |
|                         |                         |
+-------------------------+-------------------------+
```

#### case 2: saved when editor2 is active

result: editor2's cursor line was excluded

```
+-------------------------+-------------------------+
| editor1                 | editor2(active)         |
+-------------------------+-------------------------+
| line1|                  | line1                   |
| line2____               | line2____|              |
| line3                   | line3                   |
|                         |                         |
+-------------------------+-------------------------+
```

#### case 3: saved when either editor1 nor editor2 was active

This situation happens when `Window: Save All` command was fired.

result: just removed all trailing spaces

```
+-------------------------+-------------------------+
| editor1                 | editor2                 |
+-------------------------+-------------------------+
| line1|                  | line1                   |
| line2                   | line2|                  |
| line3                   | line3                   |
|                         |                         |
|                         +-------------------------+
|                         | editor3(active)         |
|                         +-------------------------+
|                         | abc                     |
|                         | def                     |
+-------------------------+-------------------------+
```

### Alternate Designs

Currently same buffer have multiple `buffer.onWillSave` hook.
By making this subscription per buffer basis, I think most behavior frustration described in #76 would be fixed.
But as far as I experimented it in my mind, the behavioral result would be same in that case.

So as my understanding making `buffer.onWillSave` subscription to per buffer-basis is kind of refactoring.
So not included in this PR.

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

Users are  no longer surprised by trailing WS at cursor line is removed in spite of `ignoreWhitespaceOnCurrentLine` is `true`.
This was happened when multiple same file is opened in multiple editors.

### Possible Drawbacks

None
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

Fix #76
<!-- Enter any applicable Issues here -->
