### PR TITLE
Also accept text.md as a valid Markdown scope

### DIFF
--- a/lib/whitespace.js
+++ b/lib/whitespace.js
@@ -149,7 +149,7 @@ module.exports = class Whitespace {
     })
 
     const keepMarkdownLineBreakWhitespace =
-      grammarScopeName === 'source.gfm' &&
+      grammarScopeName === ('source.gfm' || 'text.md') &&
       atom.config.get('whitespace.keepMarkdownLineBreakWhitespace')
 
     buffer.transact(() => {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Appended an if statement to allow for either source.gfm or text.md to be valid scope names for Markdown files.

### Alternate Designs

Ideally, there'd be some standard to detect whether content is Markdown without relying on a scope name, which is a little overkill for this feature. I think the proposed change is acceptable.

### Benefits

language-gfm isn't the only Markdown grammar. This patch helps serve a larger audience.

### Possible Drawbacks

None?

### Applicable Issues

- https://github.com/burodepeper/language-markdown/issues/200
- https://github.com/atom/whitespace/issues/167
- https://github.com/atom/whitespace/issues/166
