### PR TITLE
Add feature to flatten tabs after first non-whitespace character

### DIFF
--- a/lib/whitespace.js
+++ b/lib/whitespace.js
@@ -30,6 +30,14 @@ module.exports = class Whitespace {
         }
       },
 
+      'whitespace:flatten-tabs-after-non-whitespace-character': () => {
+        let editor = atom.workspace.getActiveTextEditor()
+        if (editor) {
+          this.flattenTabsAfterNonWhitespaceCharacter(editor, editor.getGrammar().scopeName)
+          editor.save()
+        }
+      },
+
       'whitespace:save-without-trailing-whitespace': () => {
         let editor = atom.workspace.getActiveTextEditor()
 
@@ -77,6 +85,10 @@ module.exports = class Whitespace {
     let bufferSavedSubscription = buffer.onWillSave(() => {
       return buffer.transact(() => {
         let scopeDescriptor = editor.getRootScopeDescriptor()
+
+        if (atom.config.get('whitespace.flattenTabsAfterNonWhitespaceCharacter', {scope: scopeDescriptor})) {
+          this.flattenTabsAfterNonWhitespaceCharacter(editor)
+        }
 
         if (atom.config.get('whitespace.removeTrailingWhitespace', {
           scope: scopeDescriptor
@@ -185,6 +197,57 @@ module.exports = class Whitespace {
         }
       }
     })
+  }
+
+  flattenTabsAfterNonWhitespaceCharacter (editor) {
+    let selectedRanges = editor.getSelectedBufferRanges()
+    let buffer = editor.getBuffer()
+    let tabSize = editor.getTabLength()
+    let lineCount = buffer.getLineCount()
+    let newBuffer = ''
+    let newRanges = selectedRanges.map((range) => {
+      return new Range(new Point(range.start.row, 0), new Point(range.end.row, 0))
+    })
+    for (let r = 0; r < lineCount; r++) {
+      let line = buffer.lineForRow(r).split('')
+      let seenNonWhitespace = false
+      let actualIndex = 0
+      let selectIndex = 0
+      for (let c = 0; c < line.length + 1; c++) {
+        let currentChar = line[c]
+        let spaceSize = 0
+        if (!seenNonWhitespace && [' ', '\t'].indexOf(currentChar) === -1) {
+          seenNonWhitespace = true
+        }
+        if (currentChar === '\t') {
+          spaceSize = tabSize - (actualIndex % tabSize)
+          actualIndex += spaceSize
+          selectIndex += spaceSize
+          if (seenNonWhitespace) {
+            line[c] = ' '.repeat(spaceSize)
+          } else {
+            selectIndex -= (spaceSize - 1)
+          }
+        } else {
+          actualIndex++
+          selectIndex++
+        }
+        let selectionIndex = selectIndex - (seenNonWhitespace && currentChar === '\t' ? spaceSize : 1)
+        for (let s = 0; s < selectedRanges.length; s++) {
+          if (selectedRanges[s].start.row === r && selectedRanges[s].start.column === c) {
+            newRanges[s].start.row = selectedRanges[s].start.row
+            newRanges[s].start.column = selectionIndex
+          }
+          if (selectedRanges[s].end.row === r && selectedRanges[s].end.column === c) {
+            newRanges[s].end.row = selectedRanges[s].end.row
+            newRanges[s].end.column = selectionIndex
+          }
+        }
+      }
+      newBuffer += line.join('') + '\n'
+    }
+    buffer.setText(newBuffer)
+    editor.setSelectedBufferRanges(newRanges)
   }
 
   ensureSingleTrailingNewline (editor) {

--- a/menus/whitespace.cson
+++ b/menus/whitespace.cson
@@ -10,6 +10,7 @@
         { 'label': 'Convert Tabs To Spaces', 'command': 'whitespace:convert-tabs-to-spaces' }
         { 'label': 'Convert Spaces To Tabs', 'command': 'whitespace:convert-spaces-to-tabs' }
         { 'label': 'Convert All Tabs To Spaces', 'command': 'whitespace:convert-all-tabs-to-spaces' }
+        { 'label': 'Flatten Tabs After Non-Whitespace Character', 'command': 'whitespace:flatten-tabs-after-non-whitespace-character' }
       ]
     ]
   }

--- a/package.json
+++ b/package.json
@@ -77,6 +77,11 @@
       "type": "boolean",
       "default": true,
       "description": "If the buffer doesn't end with a newline character when it's saved, then append one. If it ends with more than one newline, remove all but one. To disable/enable for a certain language, use [syntax-scoped properties](https://github.com/atom/whitespace#readme) in your `config.cson`."
+    },
+    "flattenTabsAfterNonWhitespaceCharacter": {
+      "type": "boolean",
+      "default": false,
+      "description": "After encountering a non-whitespace character on a line, convert all tabs there after to spaces whilst respecting tab-stops. Executed automatically on save when enabled. To disable/enable for a certain language, use [syntax-scoped properties](https://github.com/atom/whitespace#readme) in your `config.cson`."
     }
   }
 }


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

To explain what this feature really does, it is useful to consider what issue it aimed to solve in the first place. Consider the animation below:

![problem-optim](https://user-images.githubusercontent.com/5500199/44071207-627e0b6a-9f4d-11e8-870c-02d8e1edb293.gif)

In the above example, there is a javadoc block comment and it's columns are neatly organized with tabs. The issue really happens when one tries to open the file within a different text editor with different tab lengths configured.  It will ruin the column structure that was previously in place.

The feature that is proposed to be added will be called **Flatten Tabs After First Non-Whitespace Character** and it will be executed on file save as well as give the user the option to dispatch the event within the command palette. It will convert all tabs to spaces (while respecting tab length and tab stops) that occur after a non-whitespace character is observed on a line (tabs and spaces). Selection ranges are also taken into account. Once a tab is converted to spaces the selection range changes appropriately so that the start and end of each selection range is not _visibly_ moved. Below you can see the same example as above, but with the feature enabled:

![example](https://user-images.githubusercontent.com/5500199/44071595-abf8e042-9f4f-11e8-9004-537f21e344fb.gif)

An important note to mention is that this feature is executed before the _Remove Trailing Whitespace_ feature. This means that if _Remove Trailing Whitespace_ is disabled, then the trailing whitespace is also converted into spaces. Otherwise, the trailing whitespace is removed.

Some of the visible changes can be found below (outlined in red). Included is a configurable option to execute this feature on file save:

![config-on-save](https://user-images.githubusercontent.com/5500199/44070976-4360af5e-9f4c-11e8-94e5-300f80a24a53.png)

As well as a command within the command palette to execute this feature:

![atom-command](https://user-images.githubusercontent.com/5500199/44070975-42135cdc-9f4c-11e8-8193-53e458f169fc.png)

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

Another way that this behavior can be achieved is by modifying the `Convert All Tabs To Spaces` feature by fixing the following:

- Respect tab stops when converting
- Modify selection ranges after conversion
- Allow option to execute `Convert All Tabs To Spaces` automatically on file save

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

- Files will preserve it's formatted structure whenever a tab character is used in the middle of a line.
- Constant formatting when working across different text editors since tabs are flattened to spaces.
- Tab-stops and tab-lengths are taken into account when flattening to spaces
- Leading whitespace is not affected.
- Integrates nicely with other whitespace features, i.e. trim trailing whitespace.
- Selection ranges are converted appropriately so start and end range is visibly the same after flattening to spaces.
- Converts on save (if enabled) so user does not have to think about it.
- Command is added to command palette for manual execution.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

Every tab character on each line that has a non-whitespace character proceeding it is flattened to spaces. It is possible to run into the case where a string contains a hard coded tab character (i.e. `"a<tab>b"`) and the user does not want it to be flattened to spaces. While this can be avoided by simply using `"a\tb"`, it is a case where this is an unwanted behavior.  For this very reason, this feature is disabled by default.

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

Not applicable to my knowledge.

<!-- Enter any applicable Issues here -->
