### PR TITLE
Add option to ignore comment lines

### DIFF
--- a/lib/whitespace.js
+++ b/lib/whitespace.js
@@ -148,11 +148,18 @@ module.exports = class Whitespace {
       scope: scopeDescriptor
     })
 
+    const ignoreommentLines = atom.config.get('whitespace.ignoreCommentLines', {
+      scope: scopeDescriptor
+    })
+
     const keepMarkdownLineBreakWhitespace =
       grammarScopeName === ('source.gfm' || 'text.md') &&
       atom.config.get('whitespace.keepMarkdownLineBreakWhitespace')
 
     buffer.transact(() => {
+      const languageMode = buffer.getLanguageMode()
+      const hasIsRowCommented = languageMode.isRowCommented
+
       // TODO - remove this conditional after Atom 1.19 stable is released.
       if (buffer.findAllSync) {
         const ranges = buffer.findAllSync(TRAILING_WHITESPACE_REGEX)
@@ -161,6 +168,7 @@ module.exports = class Whitespace {
           const row = range.start.row
           const trailingWhitespaceStart = ranges[i].start.column
           if (ignoreCurrentLine && cursorRows.has(row)) continue
+          if (ignoreommentLines && hasIsRowCommented && languageMode.isRowCommented(row)) continue
           if (ignoreWhitespaceOnlyLines && trailingWhitespaceStart === 0) continue
           if (keepMarkdownLineBreakWhitespace) {
             const whitespaceLength = range.end.column - range.start.column

--- a/package.json
+++ b/package.json
@@ -63,6 +63,11 @@
       "default": true,
       "description": "Markdown uses two or more spaces at the end of a line to signify a line break. Enable this option to keep this whitespace in Markdown files, even if other settings would remove it."
     },
+    "ignoreCommentLines": {
+      "type": "boolean",
+      "default": false,
+      "description": "Skip removing trailing whitespace on comment lines. To disable/enable for a certain language, use [syntax-scoped properties](https://github.com/atom/whitespace#readme) in your `config.cson`."
+    },
     "ignoreWhitespaceOnCurrentLine": {
       "type": "boolean",
       "default": true,


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Add an option to ignore comment lines. The motivation is similar to https://github.com/atom/whitespace/pull/168, but this is a simple solution that covers 90% of the cases I see of conflicting whitespace treatment. Namely, comment blocks in some IDEs are given a trailing space inside the block (e.g. in Java, the `*`s in the middle of the block that are otherwise blank lines are given a trailing space. The option to ignore comment lines is sensible and avoids a lot of noise in PRs for teams where some are using IDEs that have this behavior.

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

The existing pull request was considered. It is a bit stale and slightly more complicated that this solution, and covers a slightly different (though perhaps more universally desired) set of use cases.

### Benefits

<!-- What benefits will be realized by the code change? -->

Allow users to turn on the ignore-comments option, which avoids a fair amount of back-and-forth noise in PRs when some members' text editors add spaces back in to comment blocks.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

Extra check during save will slightly increase save time, though it is pretty minimal. Not fully understanding the `languageMode` object, I would suggest there may be some risk that a bug would prevent saving when this feature is activated if `languageMode.isRowCommented(row)` can break under some situations; however, disabling the option results the check being skipped.

### Applicable Issues

<!-- Enter any applicable Issues here -->

PR currently lacks testing as I do not know how to manipulate the test code to provide different language modes. I would be happy to work on this with some pointers, even just to another package that has tests that must test different language behavior.