### PR TITLE
Trim Whitespaces by Default on Current Line

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     },
     "ignoreWhitespaceOnCurrentLine": {
       "type": "boolean",
-      "default": true,
+      "default": false,
       "description": "Skip removing trailing whitespace on the line which the cursor is positioned on when the buffer is saved. To disable/enable for a certain language, use [syntax-scoped properties](https://github.com/atom/whitespace#readme) in your `config.cson`."
     },
     "ignoreWhitespaceOnlyLines": {


### PR DESCRIPTION
This is kinda annoying behavior (as new user) since by default Atom trimming all whitespaces except for the current line, so it will be better if also set this default value to true. Also I think no one wants to leave any trailing whitespaces intentionally even on the current line.