### PR TITLE
Accept multiple markdown scope names

### DIFF
--- a/lib/whitespace.js
+++ b/lib/whitespace.js
@@ -148,8 +148,9 @@ module.exports = class Whitespace {
       scope: scopeDescriptor
     })
 
+    const markdownGrammars = ['source.gfm', 'text.md']
     const keepMarkdownLineBreakWhitespace =
-      grammarScopeName === ('source.gfm' || 'text.md') &&
+      markdownGrammars.includes(grammarScopeName) &&
       atom.config.get('whitespace.keepMarkdownLineBreakWhitespace')
 
     buffer.transact(() => {


### PR DESCRIPTION
### Description of the Change

I made a mistake in #177.

For whatever reason, I wrote a quick patch in my browser, and obviously, this code would never yield anything useful, _because it is just silly javascript_. The discussion in #185 made me verify my patch. This new patch should actually do something, while I have to admit that I've only verified it via Chrome's console. My test below seems valid enough.

```js
const markdownGrammars = ['source.gfm', 'text.md']

let grammarScopeName = 'text.md'
markdownGrammars.includes(grammarScopeName) // true

grammarScopeName = 'source.js'
markdownGrammars.includes(grammarScopeName) // false
```

### Alternate Designs

Not applicable

### Benefits

Not applicable

### Possible Drawbacks

Not fully tested from within Atom. This patch wouldn't break anything any further, at least...

### Applicable Issues

Not applicable
